### PR TITLE
Refactor Amazon Polly provider with abstract base class

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![logo](./images/litetts-logo.png)
 
-A lightweight wrapper to unify multiple text-to-speech (TTS) services. It aims to provide a single interface for services such as OpenAI Whisper, tts-1, Google AI Studio, IBM Watson, and local Voicevox instances.
+A lightweight wrapper to unify multiple text-to-speech (TTS) services. It aims to provide a single interface for services such as OpenAI Whisper, tts-1, Google AI Studio, IBM Watson, Amazon Polly, and local Voicevox instances.
 
 This project is managed using **pnpm** and implemented primarily in **TypeScript**.
 

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -3,12 +3,14 @@ import { openai } from './openai.js';
 import { google } from './google.js';
 import { watson } from './watson.js';
 import { voicevox } from './voicevox.js';
+import { polly } from './polly.js';
 
 export const providers: Record<string, Provider> = {
   openai,
   google,
   watson,
-  voicevox
+  voicevox,
+  polly
 };
 
 export { schemas } from './schemas.js';

--- a/src/providers/polly.ts
+++ b/src/providers/polly.ts
@@ -1,0 +1,39 @@
+import { Provider, Voice, SynthesizeOptions } from './types.js';
+
+/**
+ * Base class for Amazon Polly providers.
+ * Concrete implementations should override the voice list and
+ * speech synthesis logic.
+ */
+export abstract class PollyBase implements Provider {
+  readonly id = 'polly';
+
+  abstract voices(): Promise<Voice[]>;
+
+  abstract tts(text: string, opts: SynthesizeOptions): Promise<string>;
+
+  async status(): Promise<'ok' | 'ng'> {
+    return 'ok';
+  }
+}
+
+/**
+ * Simple placeholder implementation of the Amazon Polly provider.
+ * This returns example URLs instead of calling the real API.
+ */
+export class PollyProvider extends PollyBase {
+  private voicesList: Voice[] = [
+    { id: 'Joanna', lang: 'en-US', gender: 'female' }
+  ];
+
+  async voices(): Promise<Voice[]> {
+    return this.voicesList;
+  }
+
+  async tts(text: string, opts: SynthesizeOptions): Promise<string> {
+    // In a real implementation, this would call Amazon Polly's API
+    return `https://example.com/polly-${Date.now()}.mp3`;
+  }
+}
+
+export const polly: Provider = new PollyProvider();

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -45,6 +45,7 @@ test('list providers', async () => {
   const data = JSON.parse(res.body);
   assert.deepStrictEqual(Object.keys(data), ['providers']);
   assert.ok(Array.isArray(data.providers));
+  assert.ok(data.providers.includes('polly'));
   server.close();
 });
 
@@ -56,5 +57,16 @@ test('synthesize openai', async () => {
   const data = JSON.parse(res.body);
   assert.ok(typeof data.audioUrl === 'string');
   assert.ok(data.audioUrl.startsWith('https://example.com/openai-'));
+  server.close();
+});
+
+test('synthesize polly', async () => {
+  const server = createApp().listen(0);
+  const port = (server.address() as any).port;
+  const res = await post(port, '/v1/tts', { provider: 'polly', text: 'hi' });
+  assert.strictEqual(res.status, 200);
+  const data = JSON.parse(res.body);
+  assert.ok(typeof data.audioUrl === 'string');
+  assert.ok(data.audioUrl.startsWith('https://example.com/polly-'));
   server.close();
 });


### PR DESCRIPTION
## Summary
- replace Polly provider object with abstract base and concrete class
- keep placeholder implementation returning stub URLs

## Testing
- `npm test`
