### PR TITLE
2025 05 22 15 50 25/add generic class

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![logo](./images/litetts-logo.png)
 
-A lightweight wrapper to unify multiple text-to-speech (TTS) services. It aims to provide a single interface for services such as OpenAI Whisper, tts-1, Google AI Studio, IBM Watson, and local Voicevox instances.
+A lightweight wrapper to unify multiple text-to-speech (TTS) services. It aims to provide a single interface for services such as OpenAI Whisper, tts-1, Google AI Studio, IBM Watson, Amazon Polly, and local Voicevox instances.
 
 This project is managed using **pnpm** and implemented primarily in **TypeScript**.
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,49 @@
+# API Reference
+
+This page documents the HTTP endpoints exposed by the litetts server. Responses shown here reflect the current stub implementation.
+
+## `POST /v1/tts`
+
+Synthesize audio using one of the available providers.
+
+**Request body**
+
+```json
+{
+  "provider": "openai",
+  "text": "hello",
+  "language": "en-US",
+  "voice": "nova",
+  "outputFormat": "mp3"
+}
+```
+
+**Successful response**
+
+```json
+{
+  "audioUrl": "https://example.com/openai-12345.mp3"
+}
+```
+
+## `GET /v1/voices`
+
+List voices offered by a specific provider. Use the `provider` query parameter:
+
+```
+GET /v1/voices?provider=openai
+```
+
+Response contains an array of voice descriptors.
+
+## `GET /v1/providers`
+
+Returns a JSON object listing all supported provider IDs.
+
+## `GET /v1/status`
+
+Reports the operational status of each provider. Useful for health checks.
+
+## `GET /v1/schema`
+
+Outputs the unified JSON schema used when communicating with providers. This is mostly intended for programmatic clients.

--- a/docs/provider-apis.md
+++ b/docs/provider-apis.md
@@ -1,0 +1,86 @@
+# Third-Party TTS Provider API Reference
+
+This document summarises how to list available voices and request speech synthesis for various commercial text-to-speech services. The details are based on official documentation for each provider.
+
+## Amazon Polly
+
+| Item | Details |
+| ---- | ------- |
+| **Voice list** | Available via `DescribeVoices`. `GET /v1/voices` can filter by language code or engine type. Requires AWS credentials (`polly:DescribeVoices`). Response JSON contains `Voices` array with info for each voice. |
+| **Voice properties** | `Id` (voice ID like `"Joanna"`), `Name`, `LanguageCode` (e.g. `en-US`), `LanguageName`, `Gender`, `AdditionalLanguageCodes`, `SupportedEngines`. Use the **VoiceId** to synthesise. |
+| **Synthesis** | `POST /v1/speech` with JSON body. Required: `Text`, `VoiceId`, `OutputFormat` (`mp3`/`ogg_vorbis`/`pcm`/`json`). Optional: `Engine` (`standard`/`neural`), `LanguageCode`, `SampleRate`, `TextType` (`text`/`ssml`). Response is binary audio in the specified format. |
+| **Unique options** | Supports provider lexicons for custom pronunciation and an asynchronous `StartSpeechSynthesisTask` API for long-form text. |
+
+## Google Cloud Text-to-Speech
+
+| Item | Details |
+| ---- | ------- |
+| **Voice list** | `GET /v1/voices` with authentication. Optional `languageCode` filter. Returns JSON `voices` array. |
+| **Voice properties** | `name` (e.g. `"ja-JP-Wavenet-A"`), `language_codes`, `ssml_gender`, `natural_sample_rate_hertz`. Use `voice.name` as the voice ID. |
+| **Synthesis** | `POST https://texttospeech.googleapis.com/v1/text:synthesize`. JSON body with `input`, `voice`, and `audioConfig`. `audioConfig` requires `audioEncoding` (`MP3`, `OGG_OPUS`, `LINEAR16`, etc.). Optional `speakingRate`, `pitch`, `volumeGainDb`. Response JSON has `audioContent` containing base64-encoded audio. |
+| **Unique options** | Supports `effectsProfileId` for device tuning and global controls like `speakingRate`, `pitch`, and `volumeGainDb`. |
+
+## Microsoft Azure Speech Service
+
+| Item | Details |
+| ---- | ------- |
+| **Voice list** | `GET https://<region>.tts.speech.microsoft.com/cognitiveservices/voices/list` with subscription key. Returns JSON array with `Name`, `ShortName`, `DisplayName`, `Gender`, `Locale`, `VoiceType`, etc. |
+| **Voice properties** | `ShortName` (voice ID), `Gender`, `Locale`, `VoiceType`, `DisplayName`, `StyleList`, `SecondaryLocaleList`. |
+| **Synthesis** | `POST https://<region>.tts.speech.microsoft.com/cognitiveservices/v1`. Send SSML with `<voice name="ShortName">` and `<prosody>` tags for rate and pitch. `X-Microsoft-OutputFormat` header specifies output format. Returns binary audio stream. |
+| **Unique options** | Rich SSML extensions such as `<mstts:express-as style="cheerful">` and `<prosody>` for rate/pitch plus a long-form batch synthesis API. |
+
+## IBM Watson Text-to-Speech
+
+| Item | Details |
+| ---- | ------- |
+| **Voice list** | `GET /v1/voices` using Basic auth with API key. Response `voices` array with `name`, `language`, `gender`, etc. |
+| **Voice properties** | `name` (voice ID), `language`, `gender`, `description`, `customizable`, `supported_features`. |
+| **Synthesis** | `POST /v1/synthesize` with query `voice` specifying the voice ID. Body JSON `{ "text": "..." }` or SSML. `Accept` header controls output format (e.g. `audio/wav`). Response is binary audio. |
+| **Unique options** | Offers custom voice models via `customization_id` and a `timings` query for word timing metadata. |
+
+## AITalk (Docomo)
+
+| Item | Details |
+| ---- | ------- |
+| **Voice list** | No API endpoint. Use documented fixed list (e.g. `nozomi`, `seiji`, `akari`, etc.). |
+| **Voice properties** | Each voice ID corresponds to a character (gender/age). Details are given in provider documents. |
+| **Synthesis** | `POST https://api.apigw.smt.docomo.ne.jp/aiTalk/v1/textToSpeech?APIKEY=<key>` with SSML. `<voice name="...">` selects the speaker. `<prosody>` can adjust `rate`, `pitch`, `range`. Returns raw PCM audio. |
+| **Unique options** | All control is via SSML; the `<prosody>` tag allows a `range` attribute to modify intonation strength. |
+
+## HOYA VoiceText Web API
+
+| Item | Details |
+| ---- | ------- |
+| **Voice list** | No list endpoint. Voices are specified by fixed names like `show`, `haruka`, `hikari`, `takeru`, `santa`, `bear`. |
+| **Voice properties** | `speaker` parameter indicates voice. Some voices support emotions via `emotion` parameter (`happiness`, `anger`, `sadness`). |
+| **Synthesis** | `POST https://api.voicetext.jp/v1/tts` using Basic auth. Required `text` and `speaker`. Optional `emotion`, `emotion_level`, `pitch`, `speed`, `volume`, `format` (`wav`, `ogg`, `mp3`). Response is binary audio. |
+| **Unique options** | Emotion parameters (`emotion`, `emotion_level`) allow expressive speech; pitch, speed and volume are numeric percent values. |
+
+## CoeFont
+
+| Item | Details |
+| ---- | ------- |
+| **Voice list** | `GET /v2/coefonts/pro` with HMAC authentication. Returns JSON list with `coefont` (UUID), `name`, `description`, etc. |
+| **Voice properties** | `coefont` ID, `name`, `description`, `icon`, `sample`, `tags`. |
+| **Synthesis** | `POST https://api.coefont.cloud/v2/text2speech` with JSON containing `coefont` and `text`. Optional `yomi`, `accent`, `speed`, `pitch`, `kuten`, `toten`, `volume`, `format`. Responds with 302 redirect to temporary audio file URL. |
+| **Unique options** | Supports phonetic input via `yomi`, accent patterns with `accent`, and pause timing control using `kuten` and `toten`. |
+
+## ElevenLabs
+
+| Item | Details |
+| ---- | ------- |
+| **Voice list** | `GET /v1/voices` with API key. Returns list of available voices with `voice_id`, `name`, `category`, etc. |
+| **Voice properties** | `voice_id`, `name`, `category`, `description`, `labels` such as accent and gender, `preview_url`. |
+| **Synthesis** | `POST /v1/text-to-speech/{voice_id}`. Body includes `text` and optional `model_id`, `voice_settings`, `language_code`, `output_format`. Returns audio data directly. |
+| **Unique options** | `voice_settings` object supports fields like `stability` and `similarity_boost` to tweak synthesis behaviour. |
+
+## Murf AI
+
+| Item | Details |
+| ---- | ------- |
+| **Voice list** | `GET /v1/speech/voices` with API key. Response includes `voiceId`, `displayName`, `gender`, `locale`, `supportedLocales`, `availableStyles`. |
+| **Voice properties** | `voiceId`, `displayName`, `gender`, `supportedLocales[locale].availableStyles` for supported speaking styles. |
+| **Synthesis** | `POST /v1/speech/synthesize` with `text` and `voice_id`. Optional `style`, `format` (`MP3`, `WAV`, `FLAC`, etc.), `channelType`, `sampleRate`, `base64`. Response gives temporary audio URL or base64 audio. |
+| **Unique options** | Can return audio as a base64 string (`base64:true`) and choose mono or stereo output with `channelType`. |
+
+

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,39 @@
+# Usage Guide
+
+This document outlines how to run the litetts server or use it from the command line during development.
+
+## Running the API Server
+
+Use `pnpm` to start the development server via `tsx`:
+
+```bash
+pnpm dev
+```
+
+By default the server listens on port `3000`. You can change the port with the `PORT` environment variable:
+
+```bash
+PORT=4000 pnpm dev
+```
+
+Visit `http://localhost:3000/healthz` to verify the server is running.
+
+## CLI Mode
+
+The entry script also supports a simple CLI mode. Run it with the `MODE` variable set to `cli`:
+
+```bash
+MODE=cli npx tsx src/index.ts
+```
+
+This prints a short greeting to stdout. The CLI mode is useful for quick smoke tests without starting the HTTP server.
+
+## Testing
+
+Execute the test suite with:
+
+```bash
+pnpm test
+```
+
+The tests build the project and send requests to a temporary local server to validate all endpoints.

--- a/package.json
+++ b/package.json
@@ -13,9 +13,8 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "packageManager": "pnpm@10.0.0",
-  "dependencies": {
-  },
+  "packageManager": "pnpm@10.11.0+sha512.6540583f41cc5f628eb3d9773ecee802f4f9ef9923cc45b69890fb47991d4b092964694ec3a4f738a420c918a333062c8b925d312f42e4f0c263eb603551f977",
+  "dependencies": {},
   "devDependencies": {
     "tsup": "^8.5.0",
     "typescript": "^5.8.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,17 +7,16 @@ settings:
 importers:
 
   .:
-    dependencies:
+    devDependencies:
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@22.15.21)(typescript@5.8.3)
-      tsx:
-        specifier: ^4.19.4
-        version: 4.19.4
-    devDependencies:
       tsup:
         specifier: ^8.5.0
         version: 8.5.0(tsx@4.19.4)(typescript@5.8.3)
+      tsx:
+        specifier: ^4.19.4
+        version: 4.19.4
       typescript:
         specifier: ^5.8.3
         version: 5.8.3

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { createApp } from './server';
+import { createApp } from './server.js';
 
 /* ------------------------------------------------------------------ */
 /* CLI runner                                                         */

--- a/src/providers/google.ts
+++ b/src/providers/google.ts
@@ -1,4 +1,4 @@
-import { Provider, Voice, SynthesizeOptions } from './types';
+import { Provider, Voice, SynthesizeOptions } from './types.js';
 
 const voices: Voice[] = [
   { id: 'en-US-Wavenet-D', lang: 'en-US', gender: 'male' }

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -3,12 +3,14 @@ import { openai } from './openai.js';
 import { google } from './google.js';
 import { watson } from './watson.js';
 import { voicevox } from './voicevox.js';
+import { polly } from './polly.js';
 
 export const providers: Record<string, Provider> = {
   openai,
   google,
   watson,
-  voicevox
+  voicevox,
+  polly
 };
 
 export { schemas } from './schemas.js';

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,8 +1,8 @@
-import { Provider } from './types';
-import { openai } from './openai';
-import { google } from './google';
-import { watson } from './watson';
-import { voicevox } from './voicevox';
+import { Provider } from './types.js';
+import { openai } from './openai.js';
+import { google } from './google.js';
+import { watson } from './watson.js';
+import { voicevox } from './voicevox.js';
 
 export const providers: Record<string, Provider> = {
   openai,
@@ -11,4 +11,4 @@ export const providers: Record<string, Provider> = {
   voicevox
 };
 
-export { schemas } from './schemas';
+export { schemas } from './schemas.js';

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -1,4 +1,4 @@
-import { Provider, Voice, SynthesizeOptions } from './types';
+import { Provider, Voice, SynthesizeOptions } from './types.js';
 
 const voices: Voice[] = [
   { id: 'nova', lang: 'en-US', gender: 'female' },

--- a/src/providers/polly.ts
+++ b/src/providers/polly.ts
@@ -1,0 +1,39 @@
+import { Provider, Voice, SynthesizeOptions } from './types.js';
+
+/**
+ * Base class for Amazon Polly providers.
+ * Concrete implementations should override the voice list and
+ * speech synthesis logic.
+ */
+export abstract class PollyBase implements Provider {
+  readonly id = 'polly';
+
+  abstract voices(): Promise<Voice[]>;
+
+  abstract tts(text: string, opts: SynthesizeOptions): Promise<string>;
+
+  async status(): Promise<'ok' | 'ng'> {
+    return 'ok';
+  }
+}
+
+/**
+ * Simple placeholder implementation of the Amazon Polly provider.
+ * This returns example URLs instead of calling the real API.
+ */
+export class PollyProvider extends PollyBase {
+  private voicesList: Voice[] = [
+    { id: 'Joanna', lang: 'en-US', gender: 'female' }
+  ];
+
+  async voices(): Promise<Voice[]> {
+    return this.voicesList;
+  }
+
+  async tts(text: string, opts: SynthesizeOptions): Promise<string> {
+    // In a real implementation, this would call Amazon Polly's API
+    return `https://example.com/polly-${Date.now()}.mp3`;
+  }
+}
+
+export const polly: Provider = new PollyProvider();

--- a/src/providers/schemas.ts
+++ b/src/providers/schemas.ts
@@ -38,7 +38,18 @@ export const schemas = {
       properties: {
         voices: {
           type: 'array',
-          items: { type: 'string' } // 必要に応じて voice オブジェクトに拡張可
+          items: {
+            type: 'object',
+            properties: {
+              id: { type: 'string' },
+              displayName: { type: 'string' },
+              languageTag: { type: 'string' },
+              gender: { type: 'string', nullable: true },
+              meta: { type: 'object', nullable: true }
+            },
+            required: ['id', 'displayName', 'languageTag'],
+            additionalProperties: false
+          }
         }
       },
       required: ['voices'],
@@ -61,9 +72,19 @@ export const schemas = {
         provider: { type: 'string' },
         text: { type: 'string' },
         language: { type: 'string', nullable: true },
-        voice: { type: 'string', nullable: true },
-        outputFormat: { type: 'string', nullable: true },
-        options: { type: 'object', nullable: true }
+        voiceId: { type: 'string', nullable: true },
+        options: {
+          type: 'object',
+          properties: {
+            rate: { type: 'number', nullable: true },
+            pitch: { type: 'number', nullable: true },
+            emotion: { type: 'string', nullable: true },
+            format: { type: 'string', nullable: true },
+            providerExtra: { type: 'object', nullable: true }
+          },
+          additionalProperties: false,
+          nullable: true
+        }
       },
       required: ['provider', 'text'],
       additionalProperties: false

--- a/src/providers/unified.ts
+++ b/src/providers/unified.ts
@@ -1,0 +1,444 @@
+/*
+ * Unified Text-to-Speech provider abstraction layer
+ * --------------------------------------------------
+ * This file defines:
+ *   1. Generic data-structures (VoiceInfo, SynthesisOptions, …)
+ *   2. Provider interface / abstract base class
+ *   3. Concrete provider stubs for major commercial services
+ *
+ * Tech-stack assumptions
+ * ---------------------
+ * • TypeScript ("module": "NodeNext")
+ * • pnpm workspace – dependencies declared in each provider’s package.json or a shared one.
+ * • Runtime HTTP client: fetch() (global in modern Node) or cross-fetch polyfill.
+ * • CommonJS interop for SDKs (AWS SDK v3, @google-cloud/text-to-speech, etc.)
+ *
+ * NOTE: 依存SDKの import はコメントアウトしている箇所もある。実装を進める際は pnpm add してコメントアウトを外してな。
+ */
+
+// ---------------------------------------------------------------------------
+// Generic types
+// ---------------------------------------------------------------------------
+
+export type Gender = "Male" | "Female" | "Neutral" | "Unknown";
+
+export interface VoiceInfo {
+  /** Provider-unique voice identifier (e.g. "Joanna") */
+  id: string;
+  /** Human-readable display name */
+  displayName: string;
+  /** BCP-47 language tag (e.g. "en-US", "ja-JP") */
+  languageTag: string;
+  /** Speaker gender (if provided by the engine) */
+  gender?: Gender;
+  /** Additional provider-specific metadata */
+  meta?: Record<string, unknown>;
+}
+
+export interface SynthesisOptions {
+  /** Speaking rate multiplier (1 = default) */
+  rate?: number;
+  /** Pitch adjustment in semitones or percent depending on provider (0 = default) */
+  pitch?: number;
+  /** Emotion / style keyword – provider dependent (e.g. "cheerful", "angry") */
+  emotion?: string;
+  /** Desired output audio format (e.g. "mp3", "wav", provider-native ids allowed) */
+  format?: string;
+  /** Provider-specific raw options bucket */
+  providerExtra?: Record<string, unknown>;
+}
+
+export interface SynthesisRequest {
+  text: string;
+  voiceId?: string; // Use provider default when omitted
+  language?: string; // BCP-47
+  options?: SynthesisOptions;
+}
+
+export interface SynthesisResponse {
+  audioUrl: string; // Pre-signed URL / temp URL – caller may fetch binary
+}
+
+// ---------------------------------------------------------------------------
+// Provider interface & abstract base class
+// ---------------------------------------------------------------------------
+
+export interface ITTSProvider {
+  /** Machine-readable provider key (e.g. "polly") */
+  readonly name: string;
+
+  /** Return human-readable provider label */
+  readonly displayName: string;
+
+  /** Health-check – returns "ok" or throws on failure */
+  health(): Promise<string>;
+
+  /** List voices this provider offers */
+  listVoices(): Promise<VoiceInfo[]>;
+
+  /** Perform synthesis and return a URL pointing to generated audio */
+  synthesize(req: SynthesisRequest): Promise<SynthesisResponse>;
+}
+
+/**
+ * Abstract base class that offers simple helpers. Concrete subclasses must
+ * implement the abstract methods.
+ */
+export abstract class BaseTTSProvider implements ITTSProvider {
+  abstract readonly name: string;
+  abstract readonly displayName: string;
+
+  async health(): Promise<string> {
+    // naive default – override for provider-specific ping
+    return "ok";
+  }
+
+  abstract listVoices(): Promise<VoiceInfo[]>;
+  abstract synthesize(req: SynthesisRequest): Promise<SynthesisResponse>;
+}
+
+// ---------------------------------------------------------------------------
+// Provider registry (utility for /v1/providers endpoint)
+// ---------------------------------------------------------------------------
+
+export class ProviderRegistry {
+  private static _providers: Map<string, ITTSProvider> = new Map();
+
+  static register(provider: ITTSProvider) {
+    ProviderRegistry._providers.set(provider.name, provider);
+  }
+
+  static get(name: string): ITTSProvider | undefined {
+    return ProviderRegistry._providers.get(name);
+  }
+
+  static list(): string[] {
+    return [...ProviderRegistry._providers.keys()];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Concrete provider implementations (stubs)
+// ---------------------------------------------------------------------------
+
+// ### 1. Amazon Polly #########################################################
+
+/**
+ * Configuration interface for Amazon Polly
+ */
+export interface AmazonPollyConfig {
+  region: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+  // optional session token, etc.
+}
+
+export class AmazonPollyProvider extends BaseTTSProvider {
+  readonly name = "polly";
+  readonly displayName = "Amazon Polly";
+
+  private readonly cfg: AmazonPollyConfig;
+  // private readonly client: PollyClient; // @aws-sdk/client-polly
+
+  constructor(cfg: AmazonPollyConfig) {
+    super();
+    this.cfg = cfg;
+    // this.client = new PollyClient({
+    //   region: cfg.region,
+    //   credentials: {
+    //     accessKeyId: cfg.accessKeyId,
+    //     secretAccessKey: cfg.secretAccessKey,
+    //   },
+    // });
+  }
+
+  async listVoices(): Promise<VoiceInfo[]> {
+    // TODO: Uncomment when SDK installed
+    // const cmd = new DescribeVoicesCommand({});
+    // const res = await this.client.send(cmd);
+    // return (res.Voices ?? []).map((v) => ({
+    //   id: v.Id!,
+    //   displayName: v.Name ?? v.Id!,
+    //   languageTag: v.LanguageCode!,
+    //   gender: v.Gender as Gender,
+    //   meta: v,
+    // }));
+
+    // Placeholder – compile-time fallback
+    return [];
+  }
+
+  async synthesize(req: SynthesisRequest): Promise<SynthesisResponse> {
+    // const cmd = new SynthesizeSpeechCommand({
+    //   Text: req.text,
+    //   VoiceId: req.voiceId ?? "Joanna",
+    //   OutputFormat: req.options?.format ?? "mp3",
+    //   Engine: req.options?.providerExtra?.engine as "standard" | "neural" | undefined,
+    //   LanguageCode: req.language,
+    //   SampleRate: req.options?.providerExtra?.sampleRate,
+    //   TextType: req.options?.providerExtra?.ssml ? "ssml" : "text",
+    // });
+    // const { AudioStream } = await this.client.send(cmd);
+    // const url = await uploadTemp(AudioStream, req.options?.format ?? "mp3");
+    // return { audioUrl: url };
+
+    throw new Error("AmazonPolly synthesize not yet implemented");
+  }
+}
+
+// ### 2. Google Cloud TTS #####################################################
+
+export interface GoogleTTSConfig {
+  /** Path to service account JSON key or credentials object */
+  credentials: Record<string, unknown>;
+}
+
+export class GoogleTTSProvider extends BaseTTSProvider {
+  readonly name = "google";
+  readonly displayName = "Google Cloud Text-to-Speech";
+
+  private readonly cfg: GoogleTTSConfig;
+  // private readonly client: TextToSpeechClient; // @google-cloud/text-to-speech
+
+  constructor(cfg: GoogleTTSConfig) {
+    super();
+    this.cfg = cfg;
+    // this.client = new TextToSpeechClient(cfg);
+  }
+
+  async listVoices(): Promise<VoiceInfo[]> {
+    // const [res] = await this.client.listVoices({});
+    // return (res.voices ?? []).flatMap((v) =>
+    //   (v.languageCodes ?? []).map((lang) => ({
+    //     id: v.name!,
+    //     displayName: v.name!,
+    //     languageTag: lang,
+    //     gender: (v.ssmlGender?.toString() as Gender) ?? "Unknown",
+    //     meta: v,
+    //   }))
+    // );
+
+    return [];
+  }
+
+  async synthesize(req: SynthesisRequest): Promise<SynthesisResponse> {
+    throw new Error("GoogleTTS synthesize not yet implemented");
+  }
+}
+
+// ### 3. Azure Speech #########################################################
+
+export interface AzureSpeechConfig {
+  region: string;
+  subscriptionKey: string;
+}
+
+export class AzureSpeechProvider extends BaseTTSProvider {
+  readonly name = "azure";
+  readonly displayName = "Azure Speech";
+
+  constructor(private readonly cfg: AzureSpeechConfig) {
+    super();
+  }
+
+  async listVoices(): Promise<VoiceInfo[]> {
+    const endpoint = `https://${this.cfg.region}.tts.speech.microsoft.com/cognitiveservices/voices/list`;
+    const res = await fetch(endpoint, {
+      headers: {
+        "Ocp-Apim-Subscription-Key": this.cfg.subscriptionKey,
+      },
+    });
+    if (!res.ok) throw new Error(`Azure listVoices failed: ${res.status}`);
+    const voices = (await res.json()) as any[];
+    return voices.map((v) => ({
+      id: v.ShortName,
+      displayName: v.DisplayName,
+      languageTag: v.Locale,
+      gender: (v.Gender as Gender) ?? "Unknown",
+      meta: v,
+    }));
+  }
+
+  async synthesize(req: SynthesisRequest): Promise<SynthesisResponse> {
+    // Minimal SSML generator
+    const voiceId = req.voiceId ?? "en-US-JennyNeural";
+    const rate = req.options?.rate ? ` rate="${req.options.rate}"` : "";
+    const pitch = req.options?.pitch ? ` pitch="${req.options.pitch}%"` : "";
+    const ssml = `<?xml version="1.0"?><speak version="1.0" xmlns="http://www.w3.org/2001/10/synthesis" xmlns:mstts="http://www.w3.org/2001/mstts" xml:lang="${req.language ?? "en-US"}"><voice name="${voiceId}"><prosody${rate}${pitch}>${req.text}</prosody></voice></speak>`;
+
+    const res = await fetch(`https://${this.cfg.region}.tts.speech.microsoft.com/cognitiveservices/v1`, {
+      method: "POST",
+      headers: {
+        "Ocp-Apim-Subscription-Key": this.cfg.subscriptionKey,
+        "Content-Type": "application/ssml+xml",
+        "X-Microsoft-OutputFormat": req.options?.format ?? "audio-16khz-32kbitrate-mono-mp3",
+        "User-Agent": "tts-proxy",
+      },
+      body: ssml,
+    });
+    if (!res.ok) throw new Error(`Azure synthesize failed: ${res.status}`);
+    const blob = await res.arrayBuffer();
+    const url = await uploadTemp(Buffer.from(blob), req.options?.format ?? "mp3");
+    return { audioUrl: url };
+  }
+}
+
+// ### 4. IBM Watson ###########################################################
+
+export interface WatsonConfig {
+  apiKey: string;
+  serviceUrl: string; // e.g. https://api.au-syd.text-to-speech.watson.cloud.ibm.com
+}
+
+export class WatsonProvider extends BaseTTSProvider {
+  readonly name = "watson";
+  readonly displayName = "IBM Watson TTS";
+
+  constructor(private readonly cfg: WatsonConfig) {
+    super();
+  }
+
+  async listVoices(): Promise<VoiceInfo[]> {
+    const res = await fetch(`${this.cfg.serviceUrl}/v1/voices`, {
+      headers: {
+        Authorization: `Basic ${Buffer.from("apikey:" + this.cfg.apiKey).toString("base64")}`,
+      },
+    });
+    if (!res.ok) throw new Error("Watson listVoices failed");
+    const data = await res.json();
+    return (data.voices as any[]).map((v) => ({
+      id: v.name,
+      displayName: v.name,
+      languageTag: v.language,
+      gender: (v.gender as Gender) ?? "Unknown",
+      meta: v,
+    }));
+  }
+
+  async synthesize(req: SynthesisRequest): Promise<SynthesisResponse> {
+    const body = { text: req.text };
+    const params = new URLSearchParams({ voice: req.voiceId ?? "en-US_AllisonV3Voice" });
+    const res = await fetch(`${this.cfg.serviceUrl}/v1/synthesize?${params.toString()}`, {
+      method: "POST",
+      headers: {
+        Authorization: `Basic ${Buffer.from("apikey:" + this.cfg.apiKey).toString("base64")}`,
+        Accept: `audio/${req.options?.format ?? "mp3"}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) throw new Error("Watson synthesize failed");
+    const blob = await res.arrayBuffer();
+    const url = await uploadTemp(Buffer.from(blob), req.options?.format ?? "mp3");
+    return { audioUrl: url };
+  }
+}
+
+// ### 5. Stub providers for other services ###################################
+// These just throw "not implemented" for now. Implement similarly to above.
+
+export class AITalkProvider extends BaseTTSProvider {
+  readonly name = "aitalk";
+  readonly displayName = "AITalk";
+  async listVoices() { return []; }
+  async synthesize(_: SynthesisRequest): Promise<SynthesisResponse> {
+    throw new Error("AITalk synthesize not implemented");
+  }
+}
+
+export class VoiceTextProvider extends BaseTTSProvider {
+  readonly name = "voicetext";
+  readonly displayName = "HOYA VoiceText";
+  async listVoices() { return []; }
+  async synthesize(_: SynthesisRequest): Promise<SynthesisResponse> {
+    throw new Error("VoiceText synthesize not implemented");
+  }
+}
+
+export class CoeFontProvider extends BaseTTSProvider {
+  readonly name = "coefont";
+  readonly displayName = "CoeFont";
+  async listVoices() { return []; }
+  async synthesize(_: SynthesisRequest): Promise<SynthesisResponse> {
+    throw new Error("CoeFont synthesize not implemented");
+  }
+}
+
+export class ElevenLabsProvider extends BaseTTSProvider {
+  readonly name = "elevenlabs";
+  readonly displayName = "ElevenLabs";
+  async listVoices() { return []; }
+  async synthesize(_: SynthesisRequest): Promise<SynthesisResponse> {
+    throw new Error("ElevenLabs synthesize not implemented");
+  }
+}
+
+export class MurfProvider extends BaseTTSProvider {
+  readonly name = "murf";
+  readonly displayName = "Murf AI";
+  async listVoices() { return []; }
+  async synthesize(_: SynthesisRequest): Promise<SynthesisResponse> {
+    throw new Error("Murf synthesize not implemented");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helper: temporary object storage (in-memory or S3). Replace with your impl.
+// ---------------------------------------------------------------------------
+
+async function uploadTemp(buf: any, ext = "mp3"): Promise<string> {
+  // In the PoC we just store in /tmp and return a file URL; production should
+  // upload to object storage (e.g. S3, GCS) with signed URL.
+  const fs = await import("node:fs/promises");
+  const path = await import("node:path");
+  const fname = `tts_${Date.now()}.${ext}`;
+  const fpath = path.join("/tmp", fname);
+  await fs.writeFile(fpath, buf);
+  return `file://${fpath}`;
+}
+
+// ---------------------------------------------------------------------------
+// Provider registry bootstrap – Call this during application init.
+// ---------------------------------------------------------------------------
+
+export function bootstrapProviders() {
+  // Example – configure from env vars
+  if (process.env.AWS_REGION) {
+    ProviderRegistry.register(
+      new AmazonPollyProvider({
+        region: process.env.AWS_REGION,
+        accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
+        secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
+      }),
+    );
+  }
+
+  if (process.env.GOOGLE_APPLICATION_CREDENTIALS_JSON) {
+    ProviderRegistry.register(
+      new GoogleTTSProvider({
+        credentials: JSON.parse(process.env.GOOGLE_APPLICATION_CREDENTIALS_JSON),
+      }),
+    );
+  }
+
+  if (process.env.AZURE_SPEECH_KEY) {
+    ProviderRegistry.register(
+      new AzureSpeechProvider({
+        region: process.env.AZURE_SPEECH_REGION!,
+        subscriptionKey: process.env.AZURE_SPEECH_KEY!,
+      }),
+    );
+  }
+
+  if (process.env.WATSON_TTS_APIKEY) {
+    ProviderRegistry.register(
+      new WatsonProvider({
+        apiKey: process.env.WATSON_TTS_APIKEY,
+        serviceUrl: process.env.WATSON_TTS_URL!,
+      }),
+    );
+  }
+
+  // TODO: register remaining providers when their implementations are ready.
+}
+

--- a/src/providers/voicevox.ts
+++ b/src/providers/voicevox.ts
@@ -1,4 +1,4 @@
-import { Provider, Voice, SynthesizeOptions } from './types';
+import { Provider, Voice, SynthesizeOptions } from './types.js';
 
 const voices: Voice[] = [
   { id: 'voicevox:四国めたん', lang: 'ja-JP', gender: 'female' }

--- a/src/providers/watson.ts
+++ b/src/providers/watson.ts
@@ -1,4 +1,4 @@
-import { Provider, Voice, SynthesizeOptions } from './types';
+import { Provider, Voice, SynthesizeOptions } from './types.js';
 
 const voices: Voice[] = [
   { id: 'watson:ja-JP_EmiV3Voice', lang: 'ja-JP', gender: 'female' }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,5 @@
 import http from 'http';
-import { providers, schemas } from './providers';
+import { providers, schemas } from './providers/index.js';
 
 export function createApp(): any {
   return http.createServer((req: any, res: any) => {

--- a/src/shims-node.d.ts
+++ b/src/shims-node.d.ts
@@ -4,3 +4,15 @@ declare module 'http' {
 }
 
 declare const process: any;
+
+declare const Buffer: any;
+
+declare module 'node:fs/promises' {
+  const anything: any;
+  export = anything;
+}
+
+declare module 'node:path' {
+  const anything: any;
+  export = anything;
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -45,6 +45,7 @@ test('list providers', async () => {
   const data = JSON.parse(res.body);
   assert.deepStrictEqual(Object.keys(data), ['providers']);
   assert.ok(Array.isArray(data.providers));
+  assert.ok(data.providers.includes('polly'));
   server.close();
 });
 
@@ -56,5 +57,16 @@ test('synthesize openai', async () => {
   const data = JSON.parse(res.body);
   assert.ok(typeof data.audioUrl === 'string');
   assert.ok(data.audioUrl.startsWith('https://example.com/openai-'));
+  server.close();
+});
+
+test('synthesize polly', async () => {
+  const server = createApp().listen(0);
+  const port = (server.address() as any).port;
+  const res = await post(port, '/v1/tts', { provider: 'polly', text: 'hi' });
+  assert.strictEqual(res.status, 200);
+  const data = JSON.parse(res.body);
+  assert.ok(typeof data.audioUrl === 'string');
+  assert.ok(data.audioUrl.startsWith('https://example.com/polly-'));
   server.close();
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,0 +1,60 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import http from 'http';
+import { createApp } from '../src/server.js';
+
+function get(port: number, path: string): Promise<{status: number, body: string}> {
+  return new Promise((resolve, reject) => {
+    http.get({ hostname: 'localhost', port, path }, (res: any) => {
+      let data = '';
+      res.on('data', (chunk: any) => (data += chunk));
+      res.on('end', () => resolve({ status: res.statusCode || 0, body: data }));
+    }).on('error', reject);
+  });
+}
+
+function post(port: number, path: string, json: any): Promise<{status: number, body: string}> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { hostname: 'localhost', port, path, method: 'POST', headers: { 'Content-Type': 'application/json' } },
+      (res: any) => {
+        let data = '';
+        res.on('data', (chunk: any) => (data += chunk));
+        res.on('end', () => resolve({ status: res.statusCode || 0, body: data }));
+      }
+    );
+    req.on('error', reject);
+    req.write(JSON.stringify(json));
+    req.end();
+  });
+}
+
+test('health check', async () => {
+  const server = createApp().listen(0);
+  const port = (server.address() as any).port;
+  const res = await get(port, '/healthz');
+  assert.strictEqual(res.status, 200);
+  assert.strictEqual(res.body, JSON.stringify({ status: 'ok' }));
+  server.close();
+});
+
+test('list providers', async () => {
+  const server = createApp().listen(0);
+  const port = (server.address() as any).port;
+  const res = await get(port, '/v1/providers');
+  const data = JSON.parse(res.body);
+  assert.deepStrictEqual(Object.keys(data), ['providers']);
+  assert.ok(Array.isArray(data.providers));
+  server.close();
+});
+
+test('synthesize openai', async () => {
+  const server = createApp().listen(0);
+  const port = (server.address() as any).port;
+  const res = await post(port, '/v1/tts', { provider: 'openai', text: 'hello' });
+  assert.strictEqual(res.status, 200);
+  const data = JSON.parse(res.body);
+  assert.ok(typeof data.audioUrl === 'string');
+  assert.ok(data.audioUrl.startsWith('https://example.com/openai-'));
+  server.close();
+});

--- a/test/shims-node.d.ts
+++ b/test/shims-node.d.ts
@@ -1,0 +1,10 @@
+declare module 'node:test' {
+  const test: any;
+  export default test;
+}
+
+declare module 'node:assert' {
+  const assert: any;
+  export default assert;
+}
+


### PR DESCRIPTION
## Summary

- Added a comprehensive abstraction layer for text‑to‑speech services with generic types (VoiceInfo, SynthesisOptions, etc.) and an extensible provider registry

- Implemented stub classes for Amazon Polly, Google Cloud TTS, Azure Speech, IBM Watson, and placeholder providers, plus a helper to store generated audio in /tmp and a bootstrap routine to register providers from environment variables

- Extended node shims to cover Buffer, fs/promises, and path modules